### PR TITLE
Add terminal clock

### DIFF
--- a/clock.py
+++ b/clock.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""Terminal clock that highlights seconds in red every 10 seconds."""
+import time
+from datetime import datetime
+
+RESET = "\033[0m"
+RED = "\033[31m"
+
+try:
+    while True:
+        now = datetime.now()
+        hour = now.strftime('%H')
+        minute = now.strftime('%M')
+        second = now.second
+        if second % 10 == 0:
+            sec_str = f"{RED}{second:02}{RESET}"
+        else:
+            sec_str = f"{second:02}"
+        time_str = f"{hour}:{minute}:{sec_str}"
+        print(f"\r{time_str}", end='', flush=True)
+        time.sleep(1)
+except KeyboardInterrupt:
+    print()
+


### PR DESCRIPTION
## Summary
- add a simple clock that prints hour:minute:second
- highlight the second field in red every 10 seconds

## Testing
- `python3 clock.py`

------
https://chatgpt.com/codex/tasks/task_e_684d6703ff44832d8a5c1af28e4807c9